### PR TITLE
Supports the bower plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,41 @@
 This provides a bower installable QUnit that fires off all tests 
 when the app has finished loading.
 
-Currently, it has no dependencies until [this issue](https://github.com/jquery/qunit/issues/723)
-is closed.
+## Install
+
+From NPM:
+
+```shell
+npm install steal-qunit --save-dev
+```
+
+From Bower:
+
+```shell
+bower install steal-qunit --save-dev
+```
+
+## Configuration
+
+If you are using the [npm](http://stealjs.com/docs/npm.html) or [bower](http://stealjs.com/docs/bower.html)
+plugins no configuration is needed. Otherwise configure the `paths` and `meta` properties:
+
+```js
+System.config({
+	paths: {
+		"steal-qunit/*": "path/to/steal-qunit/*.js",
+		"steal-qunit": "path/to/steal-qunit/steal-qunit.js",
+		"qunitjs/qunit/*": "path/to/qunit/qunit/*.js",
+		"qunitjs/qunit/qunit.css": "path/to/qunit/qunit/qunit.css"
+	},
+	meta: {
+		"qunitjs/qunit/qunit": {
+			"format": "global",
+			"exports": "QUnit",
+			"deps": [
+				"steal-qunit/add-dom"
+			]
+		}
+	}
+});
+```

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,8 @@
 {
   "name": "steal-qunit",
+	"main": "steal-qunit.js",
   "version": "0.0.1",
-  "devDependencies": {
+  "dependencies": {
     "qunit": "~1.14.0"
   },
   "ignore": [
@@ -11,5 +12,20 @@
     "Gruntfile.js",
     "node_modules",
     "test"
-  ]
+  ],
+	"system": {
+		"paths": {
+			"qunitjs/qunit/*": "bower_components/qunit/qunit/*.js",
+			"qunitjs/qunit/qunit.css": "bower_components/qunit/qunit/qunit.css"
+		},
+		"meta": {
+			 "qunitjs/qunit/qunit": {
+					"format": "global",
+					"exports": "QUnit",
+					"deps": [
+						"steal-qunit/add-dom"
+					]
+				}
+		}
+	}
 }

--- a/test/test-bower.html
+++ b/test/test-bower.html
@@ -1,0 +1,10 @@
+<script>
+	steal = {
+		paths: {
+			"steal-qunit/*": "*.js"
+		}
+	}
+</script>
+<script src='../node_modules/steal/steal.js'
+	data-config="../bower.json!bower"
+	data-main="test/test"></script>


### PR DESCRIPTION
This adds config to make the bower plugin work automatically, there is a
test at `test/test-bower.html`. Also explains how to configure manually.
Closes #3
