### PR TITLE
Work with live-reload

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+; Unix-style newlines
+[*]
+end_of_line = LF
+indent_style = tab
+indent_size = 4

--- a/steal-qunit.js
+++ b/steal-qunit.js
@@ -1,5 +1,49 @@
 "format amd";
-define(["qunitjs/qunit/qunit","qunitjs/qunit/qunit.css!"], function(QUnit){
+define([
+	"@loader",
+	"module",
+	"qunitjs/qunit/qunit",
+	"qunitjs/qunit/qunit.css!"
+], function(loader, module, QUnit){
+
+	if(loader.has("live-reload")) setupLiveReload();
+
+	function setupLiveReload(){
+		loader.import("live-reload", { name: module.id }).then(function(reload){
+			reload(updateResults);
+		});
+
+		// Check to make sure all tests have passed and update the banner class.
+		function updateResults() {
+			var tests = document.getElementById("qunit-tests").children;
+			var node, passed = true;
+			for(var i = 0, len = tests.length; i < len; i++) {
+				node = tests.item(i);
+				removeAllButLast(node, "runtime");
+				if(node.className !== "pass") {
+					passed = false;
+					break;
+				}
+			}
+			document.getElementById("qunit-banner").className = passed ?
+				"qunit-pass" : "qunit-fail";
+
+		}
+
+		function removeAllButLast(parent, className){
+			var node, nodes = [];
+			var children = parent.children;
+			for(var i = 0, len = children.length; i < len; i++) {
+				node = children.item(i);
+				if(node.className === className) nodes.push(node);
+			}
+			while(nodes.length > 1) {
+				node = nodes.shift();
+				parent.removeChild(node);
+			}
+		}
+	}
+
 	QUnit.config.autorun = false;
 	steal.done().then(function() {
 		if (window.Testee) {


### PR DESCRIPTION
This updates steal-qunit to work with live-reload. Whenever a QUnit test
module is reloaded its tests will be reran; this already works. This
change just makes it so that steal-qunit will update the UI to remove
extra elements that are added and updates the qunit-banner to show the
tests as either passing or failing.

Closes #7
