### PR TITLE
Bower update

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,6 @@
   "ignore": [
     "**/.*",
     "package.json",
-    "bower.json",
     "Gruntfile.js",
     "node_modules",
     "test"

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "steal-qunit",
-	"main": "steal-qunit.js",
-  "version": "0.0.4",
+  "main": "steal-qunit.js",
+  "version": "0.1.1-pre.0",
   "dependencies": {
     "qunit": "~1.14.0"
   },
@@ -13,19 +13,19 @@
     "node_modules",
     "test"
   ],
-	"system": {
-		"paths": {
-			"qunitjs/qunit/*": "bower_components/qunit/qunit/*.js",
-			"qunitjs/qunit/qunit.css": "bower_components/qunit/qunit/qunit.css"
-		},
-		"meta": {
-			 "qunitjs/qunit/qunit": {
-					"format": "global",
-					"exports": "QUnit",
-					"deps": [
-						"steal-qunit/add-dom"
-					]
-				}
-		}
-	}
+  "system": {
+    "paths": {
+      "qunitjs/qunit/*": "bower_components/qunit/qunit/*.js",
+      "qunitjs/qunit/qunit.css": "bower_components/qunit/qunit/qunit.css"
+    },
+    "meta": {
+       "qunitjs/qunit/qunit": {
+          "format": "global",
+          "exports": "QUnit",
+          "deps": [
+            "steal-qunit/add-dom"
+          ]
+        }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steal-qunit",
-  "version": "0.1.0",
+  "version": "0.1.1-pre.0",
   "description": "A bower package for QUnit and StealJS",
   "main": "steal-qunit",
   "system": {


### PR DESCRIPTION
This bumps the versions to 0.1.1-pre.0. Removed bower.json from ignore list.
