### PR TITLE
Update results when QUnit is complete.

### DIFF
--- a/steal-qunit.js
+++ b/steal-qunit.js
@@ -1,17 +1,14 @@
 "format amd";
 define([
 	"@loader",
-	"module",
 	"qunitjs/qunit/qunit",
 	"qunitjs/qunit/qunit.css!"
-], function(loader, module, QUnit){
+], function(loader, QUnit){
 
 	if(loader.has("live-reload")) setupLiveReload();
 
 	function setupLiveReload(){
-		loader.import("live-reload", { name: module.id }).then(function(reload){
-			reload(updateResults);
-		});
+		QUnit.done(updateResults);
 
 		// Check to make sure all tests have passed and update the banner class.
 		function updateResults() {


### PR DESCRIPTION
For live-reload, rather than updating after a reload just always update
when QUnit is done. The reason is, updating on a reload could cause
problems if the tests are not complete. In reality we want to wait for
them to be finished.
