### PR TITLE
Add QUnit reporting for SauceLabs

### DIFF
--- a/steal-qunit.js
+++ b/steal-qunit.js
@@ -5,7 +5,11 @@ define([
 	"qunitjs/qunit/qunit.css!"
 ], function(loader, QUnit){
 
-	if(loader.has("live-reload")) setupLiveReload();
+	if(loader.has("live-reload")) {
+		setupLiveReload();
+	}
+
+	setupSauceLabsReporting();
 
 	function setupLiveReload(){
 		QUnit.done(updateResults);
@@ -39,6 +43,36 @@ define([
 				parent.removeChild(node);
 			}
 		}
+	}
+
+	function setupSauceLabsReporting() {
+		var log = [];
+		  
+		QUnit.done(function (test_results) {
+		  var tests = [];
+		  for(var i = 0, len = log.length; i < len; i++) {
+		    var details = log[i];
+		    tests.push({
+		      name: details.name,
+		      result: details.result,
+		      expected: details.expected,
+		      actual: details.actual,
+		      source: details.source
+		    });
+		  }
+		  test_results.tests = tests;
+		  
+		  window.global_test_results = test_results;
+		});
+
+		QUnit.testStart(function(testDetails){
+		  QUnit.log(function(details){
+		    if (!details.result) {
+		      details.name = testDetails.name;
+		      log.push(details);
+		    }
+		  });
+		});
 	}
 
 	QUnit.config.autorun = false;


### PR DESCRIPTION
This code is necessary to [set up QUnit reporting with Saucelabs](https://wiki.saucelabs.com/display/DOCS/Reporting+JavaScript+Unit+Test+Results+to+Sauce+Labs+Using+QUnit).
