### PR TITLE
Remove orphaned tests after live-reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "npm run test:browser && npm run test:live-reload",
     "publish": "git push origin && git push origin --tags",
     "test:browser": "testee test/test.html --browsers firefox --reporter Spec",
-    "test:live-reload": "live-reload-test & testee test/test-live-reload.html --browsers firefox --reporter Spec",
+    "test:live-reload": "testee test/test-live-reload.html --browsers firefox --reporter Spec",
     "release:pre": "npm version prerelease && npm publish",
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
@@ -34,9 +34,7 @@
     "grunt-cli": "^0.1.13",
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-watch": "~0.3.0",
-    "live-reload-testing": "^1.0.0",
-    "steal": "^1.0.0-rc2",
-    "steal-tools": "^0.11.0-pre.0",
+    "steal": "^1.0.0",
     "testee": "^0.3.0-pre.2"
   },
   "dependencies": {

--- a/steal-qunit.js
+++ b/steal-qunit.js
@@ -14,18 +14,40 @@ define([
 	function setupLiveReload(){
 		QUnit.done(updateResults);
 
+		function findTestResult(mod, id) {
+			var tests = mod.tests || [];
+			return tests.filter(function(test){
+				return test.testId === id;
+			})[0];
+		}
+
 		// Check to make sure all tests have passed and update the banner class.
 		function updateResults() {
 			var tests = document.getElementById("qunit-tests").children;
-			var node, passed = true;
+			var currentModule = QUnit.config.modules[QUnit.config.modules.length  - 1];
+			var node, passed = true, id, test, removedNodes = [];
 			for(var i = 0, len = tests.length; i < len; i++) {
 				node = tests.item(i);
-				removeAllButLast(node, "runtime");
-				if(node.className !== "pass") {
-					passed = false;
-					break;
+				id = node.id.split("-").pop();
+				test = findTestResult(currentModule, id);
+
+				// If we found a test result, check if it passed.
+				if(test) {
+					removeAllButLast(node, "runtime");
+					if(node.className !== "pass") {
+						passed = false;
+						break;
+					}
+				}
+				// If we didn't find a test result this test must have been removed
+				// so we just want to remove it from the UI.
+				else {
+					removedNodes.push(node);
 				}
 			}
+			removedNodes.forEach(function(node){
+				node.parentNode.removeChild(node);
+			});
 			document.getElementById("qunit-banner").className = passed ?
 				"qunit-pass" : "qunit-fail";
 

--- a/test/lr-helpers.js
+++ b/test/lr-helpers.js
@@ -1,0 +1,42 @@
+function Mocker(loader) {
+	this.loader = loader;
+
+	this.srcs = {};
+	this.reset = this.trap();
+}
+
+Mocker.prototype = {
+	trap: function(){
+		var fetch = this.loader.fetch;
+		var mock = this;
+		this.loader.fetch = function(load){
+			var src = mock.srcs[load.name];
+			if(src) {
+				return Promise.resolve(src);
+			}
+			return fetch.apply(this, arguments);
+		};
+
+		return function(){
+			mock.loader.fetch = fetch;
+		};
+	},
+	replace: function(moduleName, src){
+		this.srcs[moduleName] = src;
+		var liveReload = this.loader.get("live-reload").default;
+		return liveReload(moduleName);
+	},
+	// Gets the contents from a function with comments
+	getContent: function(fn){
+		var str = fn.toString();
+		var start = str.indexOf("/*");
+		str = str.substr(start + 2);
+		var end = str.lastIndexOf("*/");
+		str = str.substr(0, end);
+		return str.trim();
+	}
+};
+
+module.exports = function(loader){
+	return new Mocker(loader);
+};

--- a/test/tests/live-reload-failing/test.html
+++ b/test/tests/live-reload-failing/test.html
@@ -4,4 +4,4 @@
 		configDependencies: ["live-reload"]
 	};
 </script>
-<script src="../../../node_modules/steal/steal.js" main="test/tests/live-reload/test"></script>
+<script src="../../../node_modules/steal/steal.js" main="test/tests/live-reload-failing/test"></script>

--- a/test/tests/live-reload-failing/test.js
+++ b/test/tests/live-reload-failing/test.js
@@ -1,0 +1,11 @@
+var QUnit = require("steal-qunit");
+
+QUnit.module("some module");
+
+QUnit.test("Failing test", function(){
+	QUnit.equal(1, 2);
+});
+
+QUnit.test("Passing test", function(){
+	QUnit.equal(2, 2);
+});


### PR DESCRIPTION
After a reload some tests might have been removed. When this occurs we
should remove their failing test node and reflect the full test suite as
being passing/failing not accounting for this old test.

Closes #15