### PR TITLE
Select current module for updating the UI

### DIFF
--- a/steal-qunit.js
+++ b/steal-qunit.js
@@ -14,6 +14,13 @@ define([
 	function setupLiveReload(){
 		QUnit.done(updateResults);
 
+		function findModule(name) {
+			var mods = QUnit.config.modules;
+			return mods.filter(function(mod){
+				return mod.name === name;
+			}).pop();
+		}
+
 		function findTestResult(mod, id) {
 			var tests = mod.tests || [];
 			return tests.filter(function(test){
@@ -24,12 +31,14 @@ define([
 		// Check to make sure all tests have passed and update the banner class.
 		function updateResults() {
 			var tests = document.getElementById("qunit-tests").children;
-			var currentModule = QUnit.config.modules[QUnit.config.modules.length  - 1];
-			var node, passed = true, id, test, removedNodes = [];
+			var node, id, test, moduleName, mod;
+				passed = true, removedNodes = [];
 			for(var i = 0, len = tests.length; i < len; i++) {
 				node = tests.item(i);
 				id = node.id.split("-").pop();
-				test = findTestResult(currentModule, id);
+				moduleName = node.querySelector(".module-name").textContent;
+				mod = findModule(moduleName);
+				test = findTestResult(mod, id);
 
 				// If we found a test result, check if it passed.
 				if(test) {

--- a/test/test-live-reload.js
+++ b/test/test-live-reload.js
@@ -56,6 +56,12 @@ QUnit.test("Removing a failing test will make the tests pass", function(){
 		QUnit.test("Passing test", function(){
 			QUnit.equal(2, 2);
 		});
+
+		QUnit.module("another module");
+
+		QUnit.test("Another passing", function(){
+			QUnit.equal(1, 1);
+		});
 	*/}
 
 	F(function(){


### PR DESCRIPTION
After a live-reload we update the UI to make sure it is reflected in the
current state of tests. When searching for a test result (the most
		recent test result) we need to look for the module by its name,
		in order to find the most recent run of that module.