### PR TITLE
Update the banner correctly for failed/passing tests

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
-node_js: 0.10
+node_js: 8
 script: npm test
 before_install:
   - "export DISPLAY=:99.0"

--- a/steal-qunit.js
+++ b/steal-qunit.js
@@ -43,7 +43,8 @@ define([
 				// If we found a test result, check if it passed.
 				if(test) {
 					removeAllButLast(node, "runtime");
-					if(node.className !== "pass") {
+					if(node.hasAttribute && node.hasAttribute("class") &&
+						node.className !== "pass") {
 						passed = false;
 						break;
 					}

--- a/test/test-banner.js
+++ b/test/test-banner.js
@@ -1,0 +1,56 @@
+var QUnit = require("steal-qunit");
+var F = require("funcunit");
+
+F.attach(QUnit);
+
+QUnit.module("Banner - Test one passing", {
+	setup: function(assert){
+		var done = assert.async();
+		F.open("//tests/run-one/all-pass.html?testId=a205d21a", function(){
+			done();
+		});
+	}
+});
+
+QUnit.test("Banner shows as passing", function(){
+	F("#qunit-banner").hasClass("qunit-pass", true, "Is passing");
+});
+
+QUnit.module("Banner - Test one failing - Running all tests", {
+	setup: function(assert){
+		var done = assert.async();
+		F.open("//tests/run-one/one-fail.html", function(){
+			done();
+		});
+	}
+});
+
+QUnit.test("Banner shows as failing", function(){
+	F("#qunit-banner").hasClass("qunit-fail", true, "Is failing");
+});
+
+QUnit.module("Banner - Test one failing - Running failed test", {
+	setup: function(assert){
+		var done = assert.async();
+		F.open("//tests/run-one/one-fail.html?testId=108cbb26", function(){
+			done();
+		});
+	}
+});
+
+QUnit.test("Banner shows as failing", function(){
+	F("#qunit-banner").hasClass("qunit-fail", true, "Is failing");
+});
+
+QUnit.module("Banner - Test one failing - Running passing test", {
+	setup: function(assert){
+		var done = assert.async();
+		F.open("//tests/run-one/one-fail.html?testId=a205d21a", function(){
+			done();
+		});
+	}
+});
+
+QUnit.test("Banner shows as passing", function(){
+	F("#qunit-banner").hasClass("qunit-pass", true, "Is passing");
+});

--- a/test/test.html
+++ b/test/test.html
@@ -1,6 +1,10 @@
+<title>Smoke test</title>
 <script>
 	steal = { transpiler: "babel" };
 	window.Testee = { provider: { type: 'rest' } };
+</script>
+<script>
+	FuncUnit = { frameMode: true };
 </script>
 <script src='../node_modules/steal/steal.js'
 	data-main="test/test"></script>

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,6 @@
-import QUnit from "steal-qunit";
+var QUnit = require("steal-qunit");
+
+require("./test-banner");
 
 QUnit.module("A module");
 

--- a/test/tests/run-one/all-pass.html
+++ b/test/tests/run-one/all-pass.html
@@ -1,0 +1,9 @@
+<title>run one test</title>
+<script>
+	/* This is required for the test, don't remove */
+	steal = {
+		configDependencies: ["live-reload"]
+	};
+</script>
+<script src="../../../node_modules/steal/steal.js"
+	data-main="test/tests/run-one/all-pass"></script>

--- a/test/tests/run-one/all-pass.js
+++ b/test/tests/run-one/all-pass.js
@@ -1,0 +1,11 @@
+var QUnit = require("steal-qunit");
+
+QUnit.module("some module");
+
+QUnit.test("First test", function(){
+	QUnit.ok(true, "test one");
+});
+
+QUnit.test("Second test", function(){
+	QUnit.ok(true, "test two");
+});

--- a/test/tests/run-one/one-fail.html
+++ b/test/tests/run-one/one-fail.html
@@ -1,0 +1,9 @@
+<title>run one test</title>
+<script>
+	/* This is required for the test, don't remove */
+	steal = {
+		configDependencies: ["live-reload"]
+	};
+</script>
+<script src="../../../node_modules/steal/steal.js"
+	data-main="test/tests/run-one/one-fail"></script>

--- a/test/tests/run-one/one-fail.js
+++ b/test/tests/run-one/one-fail.js
@@ -1,0 +1,11 @@
+var QUnit = require("steal-qunit");
+
+QUnit.module("some module");
+
+QUnit.test("First test", function(){
+	QUnit.ok(false, "test one");
+});
+
+QUnit.test("Second test", function(){
+	QUnit.ok(true, "test two");
+});


### PR DESCRIPTION
When running an individual test the banner should reflect the result of
that test and not any other tests. When running all tests it should
reflect the result of all tests (with one test causing the banner to be
in a failed state).

Fixes #29